### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/aryanshivachhbca22/14cd4dbd-ff72-4cb0-ab0c-60410902d8d1/14b0960c-5dca-4788-8965-259aa235dd61/_apis/work/boardbadge/1e92d8e5-b53d-458e-b8b0-66a884595ff1)](https://dev.azure.com/aryanshivachhbca22/14cd4dbd-ff72-4cb0-ab0c-60410902d8d1/_boards/board/t/14b0960c-5dca-4788-8965-259aa235dd61/Microsoft.RequirementCategory)
 # devops_integration_repo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#18. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.